### PR TITLE
fix: meta-info

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,14 +3,14 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="/css/app.css">
         <meta name="csrf-token" content="{{ csrf_token() }}">
-        <meta name="api-token" content="">
-        <title>Laravel</title>
+        <link rel="stylesheet" href="{{ mix('/css/app.css') }}">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons">
+        <title>OSSCalendar</title>
     </head>
     <body>
       <div id="app">
       </div>
-      <script src="/js/app.js"></script>
+      <script src="{{ mix('/js/app.js') }}"></script>
     </body>
 </html>


### PR DESCRIPTION
以降もれのgoogle font iconを追加
css jsの読み込みをmixヘルパーを使用するように